### PR TITLE
Feature: Exclude Booster Switch

### DIFF
--- a/components/modal/settings.tsx
+++ b/components/modal/settings.tsx
@@ -19,7 +19,7 @@ import moment from 'moment'
 import React, { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import rules from '../../data/eu-dcc-rules.json'
-import { app, resetCounter, toggleCounter } from '../../state/app'
+import { app, resetCounter, toggleCounter, toggleExcludeBooster } from '../../state/app'
 import { CertLogic } from '../../utils/certlogic'
 import useColorMode from '../../utils/color-mode'
 import { getCountryAndState } from '../../utils/helper'
@@ -92,6 +92,17 @@ const SettingsModal = (props: Props) => {
                   {t('change')}
                 </Button>
               </Box>
+            )}
+
+            {appState.purpose.includes('+') && (
+              <FormControl display="flex" alignItems="center" mb="5">
+                <FormLabel flex="1">{t('modal.settings.purpose.excludebooster')}</FormLabel>
+                <Switch
+                  size="lg"
+                  onChange={toggleExcludeBooster}
+                  isChecked={appState.excludeBooster}
+                />
+              </FormControl>
             )}
 
             <Box my="5" display="flex" flexDirection="row">

--- a/state/app.ts
+++ b/state/app.ts
@@ -6,10 +6,11 @@ export type AppState = {
   purpose: string
   counter: number
   showCounter: boolean
+  excludeBooster: boolean
 }
 
 export const app = entity<AppState>(
-  { country: 'DE', state: '', purpose: '3G', counter: 0, showCounter: false },
+  { country: 'DE', state: '', purpose: '3G', counter: 0, showCounter: false, excludeBooster: true },
   [persistence('app')]
 )
 
@@ -43,4 +44,12 @@ export const decreaseCounter = () => {
 export const increaseCounter = () => {
   const state = app.get()
   app.set({ ...state, counter: state.counter + 1 })
+}
+
+export const toggleExcludeBooster = () => {
+  const state = app.get()
+  app.set({
+    ...state,
+    excludeBooster: !state.excludeBooster,
+  })
 }

--- a/tests/dcc-scanner.test.ts
+++ b/tests/dcc-scanner.test.ts
@@ -25,12 +25,14 @@ class DebugConfig implements IDCCScannerConfig {
   dCountry: string
   dState: string
   dPurpose: string
+  dExcludeBooster: boolean
 
   constructor(data: {
     dscList?: DSC[] | null
     country?: string
     state?: string
     purpose?: string
+    excludeBooster?: boolean
   }) {
     this.dDscList =
       data.dscList === null
@@ -44,6 +46,7 @@ class DebugConfig implements IDCCScannerConfig {
     this.dCountry = data.country ?? 'DE'
     this.dState = data.state ?? 'HH'
     this.dPurpose = data.purpose ?? '3G'
+    this.dExcludeBooster = data.excludeBooster ?? true
   }
 
   dscList(): DSC[] | null {
@@ -57,6 +60,9 @@ class DebugConfig implements IDCCScannerConfig {
   }
   purpose(): string {
     return this.dPurpose
+  }
+  excludeBooster(): boolean {
+    return this.dExcludeBooster
   }
   validationClock(): Date {
     return new Date()
@@ -253,10 +259,20 @@ test('Multiscan VAC BOOSTER 2G+', async () => {
   const certLogic = new CertLogicMock({
     validateImmunizationRulesResult: IMMUNIZATION_STATUS_BOOSTER,
   })
-  const sut = new DCCScanner(new DebugConfig({ purpose: '2G+' }), certLogic)
+  const sut = new DCCScanner(new DebugConfig({ purpose: '2G+', excludeBooster: true }), certLogic)
   sut.certificates = [vaccinationDCC()]
 
   expect(sut.isMultiScanNecessary()).toMatchObject([])
+})
+
+test('Multiscan VAC BOOSTER 2G+; exclude booster', async () => {
+  const certLogic = new CertLogicMock({
+    validateImmunizationRulesResult: IMMUNIZATION_STATUS_BOOSTER,
+  })
+  const sut = new DCCScanner(new DebugConfig({ purpose: '2G+', excludeBooster: false }), certLogic)
+  sut.certificates = [vaccinationDCC()]
+
+  expect(sut.isMultiScanNecessary()).toMatchObject([CERTIFICATE_TYPE_TEST])
 })
 
 test('Multiscan REC 2G+', async () => {
@@ -334,10 +350,20 @@ test('Multiscan VAC BOOSTER 1G+', async () => {
   const certLogic = new CertLogicMock({
     validateImmunizationRulesResult: IMMUNIZATION_STATUS_BOOSTER,
   })
-  const sut = new DCCScanner(new DebugConfig({ purpose: '1G+' }), certLogic)
+  const sut = new DCCScanner(new DebugConfig({ purpose: '1G+', excludeBooster: true }), certLogic)
   sut.certificates = [vaccinationDCC()]
 
   expect(sut.isMultiScanNecessary()).toMatchObject([])
+})
+
+test('Multiscan VAC BOOSTER 1G+; exclude booster', async () => {
+  const certLogic = new CertLogicMock({
+    validateImmunizationRulesResult: IMMUNIZATION_STATUS_BOOSTER,
+  })
+  const sut = new DCCScanner(new DebugConfig({ purpose: '1G+', excludeBooster: false }), certLogic)
+  sut.certificates = [vaccinationDCC()]
+
+  expect(sut.isMultiScanNecessary()).toMatchObject([CERTIFICATE_TYPE_TEST])
 })
 
 test('Multiscan REC 1G+', async () => {

--- a/translations/de/common.json
+++ b/translations/de/common.json
@@ -103,6 +103,7 @@
   "modal.settings.language": "Bevorzugte Sprache",
   "modal.settings.counter": "Scan-Zähler",
   "modal.settings.purpose": "Verwendungszweck",
+  "modal.settings.purpose.excludebooster": "Personen mit einer Auffrischungsimpfung von der Vorlage eines Tests ausschließen",
   "modal.settings.rules": "Regeln aktiv",
 
   "modal.result.valid": "GÜLTIG",

--- a/translations/en/common.json
+++ b/translations/en/common.json
@@ -103,6 +103,7 @@
   "modal.settings.language": "Preferred Language",
   "modal.settings.counter": "Scan Counter",
   "modal.settings.purpose": "Purpose of Use",
+  "modal.settings.purpose.excludebooster": "Exclude people with a booster from providing a test certificate",
   "modal.settings.rules": "rules active",
 
   "modal.result.valid": "VALID",

--- a/utils/dcc-scanner.ts
+++ b/utils/dcc-scanner.ts
@@ -55,6 +55,13 @@ export interface IDCCScannerConfig {
   purpose: () => string
 
   /**
+   * Exclude people with booster from providing an additional test certificate
+   *
+   * @return string
+   */
+  excludeBooster: () => boolean
+
+  /**
    * Validation clock
    *
    * @return Date
@@ -85,6 +92,9 @@ export class DCCScannerConfig implements IDCCScannerConfig {
   }
   purpose(): string {
     return app.get().purpose
+  }
+  excludeBooster(): boolean {
+    return app.get().excludeBooster
   }
   validationClock(): Date {
     return new Date()
@@ -282,7 +292,7 @@ export class DCCScanner implements IDCCScanner {
           this.config.country(),
           this.config.state()
         )
-        if (immunizationStatus !== IMMUNIZATION_STATUS_BOOSTER) {
+        if (immunizationStatus !== IMMUNIZATION_STATUS_BOOSTER || !this.config.excludeBooster()) {
           return [CERTIFICATE_TYPE_TEST]
         }
       }
@@ -309,7 +319,7 @@ export class DCCScanner implements IDCCScanner {
           this.config.country(),
           this.config.state()
         )
-        if (immunizationStatus !== IMMUNIZATION_STATUS_BOOSTER) {
+        if (immunizationStatus !== IMMUNIZATION_STATUS_BOOSTER || !this.config.excludeBooster()) {
           return [CERTIFICATE_TYPE_TEST]
         }
       }


### PR DESCRIPTION
Add feature to exclude booster certificates from not providing a test certificate.

The option can be enabled or disabled in the settings.